### PR TITLE
feat: platforms ++

### DIFF
--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -25,8 +25,12 @@ you might need a bigger server, if you want to host static sites though, these r
 As of now ZaneOps has been tested on these platforms : 
 
 - Debian-based Linux distributions (e.g., Debian, Ubuntu)
+- Red Hat-based distributions (e.g., CentOS, Fedora)
 - Raspberry Pi OS 64-bit (Raspbian) using ARM architecture
 - MacOs Mx series
+- Alpine Linux
+- NixOS
+- Arch Linux
 
 We can't assure you that zaneops will work on other platforms, but if you try and succeed, we are more than happy to add 
 it to our supported OS.

--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -43,6 +43,18 @@ it to our supported OS.
   # on Linux
   sudo apt install make curl jq openssl
 
+  # on Red Hat-based distributions
+  sudo dnf install -y make curl jq openssl
+
+  # on Alpine Linux
+  sudo apk add make curl jq openssl
+
+  # on NixOS
+  nix-shell -p gnumake curl jq openssl
+
+  # on Arch Linux
+  sudo pacman -S --noconfirm make curl jq openssl
+
   # on Mac
   brew install make curl jq openssl
   ```

--- a/src/content/docs/installation.mdx
+++ b/src/content/docs/installation.mdx
@@ -40,7 +40,7 @@ it to our supported OS.
 - Ensure you have [Docker >= `v27.0.3`](https://docs.docker.com/engine/install/) installed and are using a Unix-based machine. It's recommended to use the latest version of Docker to avoid compatibility issues.
 - Ensure you have `make`, `curl`, `jq` and `openssl` installed : 
   ```shell
-  # on Linux
+  # on Debian based distributions
   sudo apt install make curl jq openssl
 
   # on Red Hat-based distributions


### PR DESCRIPTION
## Description:
This PR updates the documentation to reflect the full list of platforms where ZaneOps has been tested and confirmed to work. It introduces grouped categories for better clarity and structure.

### Changes include:

Added support mentions for:
- CentOS
- Fedora
- Alpine Linux
- NixOS
- Arch Linux

Grouped related distributions: Red Hat-based (CentOS, Fedora)
Listed independent distros separately for precision.