### PR TITLE
fix: fix releases order in sidebar

### DIFF
--- a/src/content/docs/changelog/announcing-v1.mdx
+++ b/src/content/docs/changelog/announcing-v1.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.0
 description: 'ZaneOps v1.0 is here'
+sidebar:
+  order: 100
 # template: 'splash'
 ---
 

--- a/src/content/docs/changelog/v1.10.mdx
+++ b/src/content/docs/changelog/v1.10.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.10
 description: 'Sh...🤫 ells !'
+sidebar:
+  order: 110
 ---
 import {Aside} from '@astrojs/starlight/components';
 

--- a/src/content/docs/changelog/v1.11.mdx
+++ b/src/content/docs/changelog/v1.11.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.11
 description: 'Private repos, auto-deploy on Git push'
+sidebar:
+  order: 111
 ---
 
 import {Aside} from '@astrojs/starlight/components';

--- a/src/content/docs/changelog/v1.12.mdx
+++ b/src/content/docs/changelog/v1.12.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.12
 description: Preview environments, new design, account settings and more
+sidebar:
+  order: 112
 ---
 
 import {Aside} from '@astrojs/starlight/components';

--- a/src/content/docs/changelog/v1.13.mdx
+++ b/src/content/docs/changelog/v1.13.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.13
 description: Docker compose, Cloud waitlist, templates and more
+sidebar:
+  order: 113
 ---
 
 import {Aside} from '@astrojs/starlight/components';

--- a/src/content/docs/changelog/v1.7.mdx
+++ b/src/content/docs/changelog/v1.7.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.7
 description: 'See all the new and interesting changes in ZaneOps v1.7'
+sidebar:
+  order: 107
 ---
 
 import {Aside} from '@astrojs/starlight/components';

--- a/src/content/docs/changelog/v1.8.mdx
+++ b/src/content/docs/changelog/v1.8.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.8
 description: 'We support git repositories now'
+sidebar:
+  order: 108
 ---
 
 import {Aside} from '@astrojs/starlight/components';

--- a/src/content/docs/changelog/v1.9.mdx
+++ b/src/content/docs/changelog/v1.9.mdx
@@ -1,6 +1,8 @@
 ---
 title: ZaneOps v1.9
 description: '1, 2, 3 new builders!'
+sidebar:
+  order: 109
 ---
 
 import {Aside} from '@astrojs/starlight/components';


### PR DESCRIPTION
releases in the sidebar are sorted alphabetically. `1.10` is listed before `1.9`

| Before | After |
| --- | --- |
| <img width="466" height="475" alt="image" src="https://github.com/user-attachments/assets/dd55ebd1-d7a8-4e42-84bd-dfbf3ee631f1" /> | <img width="466" height="475" alt="image" src="https://github.com/user-attachments/assets/68cdb525-1f22-43bf-adfa-7fd9b4a7b47f" /> |